### PR TITLE
Add 4GEE (UK) configuration (234:30)

### DIFF
--- a/serviceproviders.xml
+++ b/serviceproviders.xml
@@ -5160,6 +5160,30 @@ conceived.
 		</gsm>
 	</provider>
 	<provider>
+		<name>4GEE</name>
+		<gsm>
+			<network-id mcc="234" mnc="30" />
+			<apn value="everywhere">
+				<name>EE Internet</name>
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>eesecure</username>
+				<password>secure</password>
+				<authentication method="pap"/>
+			</apn>
+			<apn value="eezone">
+				<name>EE MMS</name>
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<username>eesecure</username>
+				<password>secure</password>
+				<mmsc>http://mmsc/</mmsc>
+				<mmsproxy>149.254.201.135:8080</mmsproxy>
+				<authentication method="pap"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
 		<name>Tesco Mobile</name>
 		<gsm>
 			<network-id mcc="234" mnc="02"/>


### PR DESCRIPTION
Everything Everywhere Limited (EE) is a parent company that operates in the UK with three brands: T-Mobile, Orange and 4GEE (usually referred to as EE, to make matters confusing), with 4GEE being primarily geared towards providing the LTE service.

Nominally, they also use MNC 31/32 for T-Mobile, and in rare occassions you get 4GEE with MNC 33 (Orange) but roaming between the two is not exactly seamless, so keeping it separete. This is a rare occurence in any case.